### PR TITLE
Bumps Go in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.20.3
+FROM golang:1.21
 
 # Set destination for COPY
 WORKDIR /

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module hello
 
 go 1.21
 
-toolchain go1.21.1
-
 require tailscale.com v1.52.1
 
 require (


### PR DESCRIPTION
With this `docker build .` works.
I think we pulled in some deps that rely on Go 1.21 syntax